### PR TITLE
DP-723 Added generic http operations, refactored createRequest

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
   "rules": {
     "no-console": "error",
     "no-loops/no-loops": "error",
-    "object-curly-spacing": ["error", "always"]
+    "object-curly-spacing": ["error", "always"],
+    "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/src/__tests__/paxfulapi_test.ts
+++ b/src/__tests__/paxfulapi_test.ts
@@ -54,7 +54,7 @@ function mockCredentialsStorageReturnValue() {
     });
 }
 
-async function upload_trade_chat_attachment(file: ReadStream | Buffer) {
+async function uploadTradeChatAttachment(file: ReadStream | Buffer) {
     credentialStorage.getCredentials.mockReturnValueOnce({
         ...expectedTokenAnswer,
         expiresAt: new Date()
@@ -81,7 +81,7 @@ async function upload_trade_chat_attachment(file: ReadStream | Buffer) {
     });
 
     const paxfulApi = usePaxful(credentials, credentialStorage);
-    const answer = await paxfulApi.invoke(paxfulTradeChatImageUploadUrl, {
+    const answer = await paxfulApi.upload(paxfulTradeChatImageUploadUrl, {
         trade_hash: "random_hash",
         file
     });
@@ -104,8 +104,7 @@ describe("With the Paxful API SDK", function () {
                 access_token: expectedTokenAnswer.accessToken,
                 refresh_token: expectedTokenAnswer.refreshToken,
                 expires_in: ttl
-            }),
-            headers
+            })
         }, {
             sendAsJson: false,
         });
@@ -271,8 +270,7 @@ describe("With the Paxful API SDK", function () {
             method: "POST"
         }, {
             status: 200,
-            body: JSON.stringify(expectedTrades),
-            headers
+            body: JSON.stringify(expectedTrades)
         }, {
             sendAsJson: false
         });
@@ -297,15 +295,14 @@ describe("With the Paxful API SDK", function () {
             method: "POST"
         }, {
             status: 200,
-            body: JSON.stringify(expectedTrades),
-            headers
+            body: JSON.stringify(expectedTrades)
         }, {
             sendAsJson: false
         });
 
         const paxfulApi = usePaxful(credentials, credentialStorage);
 
-        const trades = await paxfulApi.invoke(paxfulTradeUrl);
+        const trades = await paxfulApi.post(paxfulTradeUrl);
 
         expect(trades).toMatchObject(expectedTrades);
     });
@@ -333,7 +330,7 @@ describe("With the Paxful API SDK", function () {
 
         const paxfulApi = usePaxful(credentials, credentialStorage);
 
-        const image = await paxfulApi.invoke(paxfulTradeChatImageDownloadUrl);
+        const image = await paxfulApi.download(paxfulTradeChatImageDownloadUrl);
 
         expect(image).toMatchObject(expectedImage);
     });
@@ -341,12 +338,12 @@ describe("With the Paxful API SDK", function () {
     it('I can upload my trade chat images as a ReadStream', async function () {
         const image = createReadStream(resolve(__dirname, 'paxful.png'));
 
-        await upload_trade_chat_attachment(image);
+        await uploadTradeChatAttachment(image);
     });
 
     it('I can upload my trade chat files as a Buffer content', async function () {
         const file = readFileSync(resolve(__dirname, 'paxful.txt'));
-        await upload_trade_chat_attachment(file);
+        await uploadTradeChatAttachment(file);
     });
 
     it('I can get my trades using a proxy', async function () {
@@ -362,15 +359,14 @@ describe("With the Paxful API SDK", function () {
             method: "POST"
         }, {
             status: 200,
-            body: JSON.stringify(expectedTrades),
-            headers
+            body: JSON.stringify(expectedTrades)
         }, {
             sendAsJson: false
         });
 
         const paxfulApi = usePaxful({ ...credentials, proxyAgent }, credentialStorage);
 
-        const trades = await paxfulApi.invoke(paxfulTradeUrl);
+        const trades = await paxfulApi.post(paxfulTradeUrl);
 
         expect(trades).toMatchObject(expectedTrades);
     });
@@ -447,8 +443,7 @@ describe("With the Paxful API SDK", function () {
             }
         }, {
             status: 200,
-            body: JSON.stringify(expectedTrades),
-            headers
+            body: JSON.stringify(expectedTrades)
         }, {
             sendAsJson: false
         });

--- a/src/__tests__/request_builder_test.ts
+++ b/src/__tests__/request_builder_test.ts
@@ -1,0 +1,155 @@
+import { RequestBuilder } from "../commands/Invoke";
+import { Response } from "node-fetch";
+import { Credentials } from "../oauth";
+import { mock } from "jest-mock-extended";
+import { ApiConfiguration } from "../ApiConfiguration";
+import ProxyAgent from "simple-proxy-agent";
+
+const exampleJson = '{"some": "json"}';
+
+describe("With the Request Builder", function () {
+
+    it('I can build basic request', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+        const [request, transform] = builder.build()
+        expect(request.url).toEqual("some-url")
+        expect(request.method).toEqual("GET")
+        expect(request.headers).toMatchObject({})
+        expect(request.body).toBe(null)
+
+        const response = new Response(exampleJson);
+        expect(await transform(response)).toBe(response)
+    });
+
+    it('I can send json', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder
+            .withMethod("POST")
+            .withJsonData({ some: "data" })
+
+        const [request, transform] = builder.build()
+        // eslint-disable-next-line radar/no-duplicate-string
+        expect(request.headers.get("Content-Type")).toEqual("application/json")
+        expect(request.body).toEqual(Buffer.from('{"some":"data"}'))
+
+        const response = new Response(exampleJson);
+        expect(await transform(response)).toBe(response)
+    });
+
+    it('I can send form', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder
+            .withMethod("POST")
+            .withFormData({ some: "data" })
+
+        const [request, transform] = builder.build()
+        expect(request.headers.get("Content-Type")).toEqual("application/x-www-form-urlencoded")
+        expect(request.body).toEqual(Buffer.from('some=data'))
+
+        const response = new Response(exampleJson);
+        expect(await transform(response)).toBe(response)
+    });
+
+    it('I can send multipart form', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder
+            .withMethod("POST")
+            .withMultipartFormData({ some: "data", file1: Buffer.from("123") })
+
+        const [request] = builder.build()
+        expect(request.headers.get("Content-Type")).toMatch("multipart/form-data")
+        expect(request.body.constructor.name).toEqual("FormData")
+    });
+
+    it('I can receive json', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder.acceptJson()
+
+        const [request, transform] = builder.build()
+        expect(request.headers.get("Accept")).toEqual("application/json")
+        expect(request.body).toBe(null)
+
+        const response = new Response(exampleJson);
+        expect(await transform(response)).toMatchObject({ "some": "json" })
+    });
+
+    it('I can receive text', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder.acceptText()
+
+        const [request, transform] = builder.build()
+        expect(request.body).toBe(null)
+
+        const response = new Response(exampleJson);
+        expect(await transform(response)).toEqual(exampleJson)
+    });
+
+    it('I can receive binary content', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder.acceptBinary()
+
+        const [request, transform] = builder.build()
+        expect(request.body).toBe(null)
+
+        const response = new Response(Buffer.from(exampleJson));
+        const actual = await transform(response);
+        expect(actual.constructor.name).toEqual("Blob")
+    });
+
+    it.each`
+        method
+        ${'GET'}
+        ${'POST'}
+        ${'PATCH'}
+        ${'DELETE'}
+        ${'OPTIONS'}
+  `('I can send "$method"', async function ({ method }) {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder.withMethod(method)
+
+        const [request] = builder.build()
+        expect(request.method).toEqual(method)
+    });
+
+    it('I can set custom headers', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        builder
+            .withHeader("foo", "123")
+            .withHeader("bar", "321")
+
+        const [request] = builder.build()
+        expect(request.headers.get("foo")).toEqual("123")
+        expect(request.headers.get("bar")).toEqual("321")
+    });
+
+    it('I can send authorized request', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        const credentials: Credentials = { accessToken: "foo", refreshToken: "bar", expiresAt: new Date() }
+
+        builder.withAuthorization(credentials)
+
+        const [request] = builder.build()
+        expect(request.headers.get("Authorization")).toEqual("Bearer foo")
+    });
+
+    it('I can use proxy', async function () {
+        const builder: RequestBuilder = new RequestBuilder("some-url");
+
+        const proxy = mock(ProxyAgent)
+        const config: ApiConfiguration = { clientId: "foo", clientSecret: "bar", proxyAgent: proxy }
+
+        builder.withConfig(config)
+
+        const [request] = builder.build()
+        expect(request.agent).toBe(proxy)
+    });
+});

--- a/src/commands/Invoke.ts
+++ b/src/commands/Invoke.ts
@@ -1,76 +1,111 @@
-import fetch, { BodyInit, Request, Response } from "node-fetch";
-import { ReadStream } from "fs";
-import queryString from "query-string";
-import { flatten } from "q-flat";
-import FormData from "form-data";
+import fetch, { Request, RequestInit, Response } from "node-fetch";
 
 import validateAndRefresh from "./RefreshIfNeeded";
 import retrieveImpersonatedCredentials from "./ImpersonateCredentials";
 
 import { Credentials, CredentialStorage } from "../oauth";
 import { ApiConfiguration } from "../ApiConfiguration";
+import queryString from 'query-string';
+import { flatten } from 'q-flat';
+import FormData from "form-data";
 
-export type InvokeBody = Record<string, unknown> | [] | ReadStream | Buffer;
+export type ResponseParser = (Response) => Promise<any>
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-const createRequest = (url: string, config: ApiConfiguration, credentials: Credentials, payload?: InvokeBody): Request => {
-    const headers = {
-        "Accept": "application/json",
-        "Authorization": `Bearer ${credentials.accessToken}`
-    };
-    let body: BodyInit | undefined;
-    if (url.endsWith('/trade-chat/image/upload') && payload) {
+export class RequestBuilder {
+    private url: string
+    private init: RequestInit = {};
+    private responseParser: ResponseParser = async (response: Response) => response
+
+    constructor(url: string) {
+        this.url = url;
+    }
+
+    public withMethod(method: string): RequestBuilder {
+        this.init.method = method
+        return this
+    }
+
+    public withConfig(config: ApiConfiguration): RequestBuilder {
+        this.init.agent = config.proxyAgent;
+        return this
+    }
+
+    public withHeader(header: string, value: string): RequestBuilder {
+        this.init.headers = { ...this.init.headers, [header]: value }
+        return this
+    }
+
+    public withFormData(payload?: Record<string, unknown> | []): RequestBuilder {
+        this.withHeader("Content-Type", "application/x-www-form-urlencoded")
+        this.init.body = queryString.stringify(flatten(payload), { encode: false })
+        return this
+    }
+
+    public withMultipartFormData(payload: Record<string, unknown> | []): RequestBuilder {
         const form: FormData = new FormData();
         Object.keys(payload).forEach((key) => {
             form.append(key, payload[key]);
         })
-        body = form;
-    } else {
-        headers["Content-Type"] = "application/x-www-form-urlencoded";
-        body = queryString.stringify(flatten(payload), { encode:false });
+        this.init.body = form
+        return this
     }
-    return new Request({
-        href: `${process.env.PAXFUL_DATA_HOST}${url}`
-    }, {
-        method: "POST",
-        headers,
-        agent: config.proxyAgent,
-        body
-    });
-}
 
-const convertResponse = (response: Response) => {
-    const contentType = response.headers.get("Content-Type");
-    if (contentType) {
-        if( contentType.startsWith("text/") ) {
-            return response.text()
-        } else if (contentType.indexOf("json") > 0) {
-            return response.json()
-        }
+    public withJsonData(data?: Record<string, unknown>): RequestBuilder {
+        this.withHeader("Content-Type", "application/json")
+        this.init.body = JSON.stringify(data || {})
+        return this
     }
-    return response.blob()
-        .catch(() => (
-            response.arrayBuffer()
+
+    public withAuthorization(credentials: Credentials): RequestBuilder {
+        this.withHeader("Authorization", `Bearer ${credentials.accessToken}`)
+        return this
+    }
+
+    public acceptJson(): RequestBuilder {
+        this.responseParser = async response => await response.json()
+        this.withHeader("Accept", `application/json`)
+        return this
+    }
+
+    public acceptText(): RequestBuilder {
+        this.responseParser = async response => await response.text()
+        return this
+    }
+
+    public acceptBinary(): RequestBuilder {
+        this.responseParser = async response => {
+            return response.blob()
                 .catch(() => (
-                    response.buffer()
+                    response.arrayBuffer()
+                        .catch(() => (
+                            response.buffer()
+                        ))
                 ))
-        ))
+        }
+        return this
+    }
+
+    public build(): [Request, ResponseParser]  {
+        return [new Request(this.url, this.init), this.responseParser]
+    }
 }
 
 /**
  * Retrieves personal access token and refresh token.
  *
- * @param url
- * @param payload
+ * @param requestBuilder
  * @param credentialStorage
  * @param config
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-export default async function invoke(url: string, config: ApiConfiguration, credentialStorage?: CredentialStorage, payload?: InvokeBody): Promise<any> {
+export default async function invoke(requestBuilder: RequestBuilder, config: ApiConfiguration, credentialStorage?: CredentialStorage): Promise<any> {
     const credentials = credentialStorage?.getCredentials() || await retrieveImpersonatedCredentials(config);
-    const request = createRequest(url, config, credentials, payload);
+
+    const [request, transformResponse] = requestBuilder
+        .withConfig(config)
+        .withAuthorization(credentials)
+        .build()
+
     return fetch(request)
         .then(response => validateAndRefresh(request, response, config, credentialStorage))
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .then(convertResponse);
+        .then(transformResponse);
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,13 +6,12 @@ import authorize from "./Authorize";
 import retrieveImpersonatedCredentials from "./ImpersonateCredentials";
 import retrievePersonalCredentials from "./PersonalCredentials";
 import getProfile from "./GetProfile";
-import { default as invoke, InvokeBody } from "./Invoke";
+import { default as invoke } from "./Invoke";
 
 export {
     authorize,
     retrieveImpersonatedCredentials,
     retrievePersonalCredentials,
     getProfile,
-    invoke,
-    InvokeBody
+    invoke
 };


### PR DESCRIPTION
The main idea of the PR is to add dead-simple get(), post(), etc operations that will allow sending requests to any Paxful API endpoints.
Some endpoints require json payload, that was not possible using invoke() function.

As invoke() function became too complex, decided to refactor it and introduce RequestBuilder, that hides all the complexity of request and response configuration.